### PR TITLE
Do not assume sourcemaps are separate files.

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -121,13 +121,10 @@ def find_package_data():
     for app in ['auth', 'edit', 'notebook', 'terminal', 'tree']:
         static_data.extend([
             pjoin('static', app, 'js', 'built', '*main.min.js'),
-            pjoin('static', app, 'js', 'built', '*main.min.js.map'),
         ])
     static_data.extend([
         pjoin('static', 'built', '*index.js'),
-        pjoin('static', 'built', '*index.js.map'),
         pjoin('static', 'services', 'built', '*contents.js'),
-        pjoin('static', 'services', 'built', '*contents.js.map'),
     ])
 
     components = pjoin("static", "components")


### PR DESCRIPTION
We likely want to be careful with these as it likely make the files
bigger, and add an option at release time to make these separate files, maybe,
but that should fix the build on travis. 
