### PR TITLE
drag modal dialogs by the header only

### DIFF
--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -56,7 +56,7 @@ define(function(require) {
             $("<div/>")
                 .addClass("modal-header")
                 .mousedown(function() {
-                  $(".modal").draggable();
+                  $(".modal").draggable({handle: '.modal-header'});
                 })
                 .append($("<button>")
                     .attr("type", "button")
@@ -72,9 +72,6 @@ define(function(require) {
         ).append(
             $("<div/>")
                 .addClass("modal-body")
-                .mousedown(function() {
-                  $(".modal").draggable();
-                })
                 .append(
                     options.body || $("<p/>")
                 )


### PR DESCRIPTION
without this, it is not possible to select any text using the mouse in
the contents of the modal. For example: editing the notebook metadata
JSON you end up just moving the whole box around instead of being able
to select a portion of the JSON using the mouse.